### PR TITLE
Fix display of dynamic amounts

### DIFF
--- a/components/gnosis-safe-railgun-app.tsx
+++ b/components/gnosis-safe-railgun-app.tsx
@@ -261,7 +261,7 @@ export default function GnosisSafeRailgunApp() {
                         <div key={tx.id} className="flex items-center gap-2 text-sm">
                           <CheckCircle className="w-4 h-4 text-green-600" />
                           <span className="text-gray-600">
-                            ${tx.totalAmount.toLocaleString()} to {tx.recipientCount} recipients
+                            {tx.totalAmount.toLocaleString()} to {tx.recipientCount} recipients
                           </span>
                           {tx.railgunEnabled && <Shield className="w-3 h-3 text-purple-600" />}
                         </div>
@@ -366,7 +366,7 @@ export default function GnosisSafeRailgunApp() {
                   Review Batch Payment
                 </CardTitle>
                 <CardDescription>
-                  {recipients.length} recipients • ${totalAmount.toLocaleString()} {selectedToken} total
+                  {recipients.length} recipients • {totalAmount.toLocaleString()} {selectedToken} total
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -396,7 +396,7 @@ export default function GnosisSafeRailgunApp() {
                   <div>
                     <span className="text-sm text-gray-600">Total Amount:</span>
                     <p className="font-semibold">
-                      ${totalAmount.toLocaleString()} {selectedToken}
+                      {totalAmount.toLocaleString()} {selectedToken}
                     </p>
                   </div>
                   <div>

--- a/components/shotgun-blast-app.tsx
+++ b/components/shotgun-blast-app.tsx
@@ -189,7 +189,9 @@ export default function ShotgunBlastApp() {
                     Safe Connected
                   </Badge>
                   <div className="text-right text-sm">
-                    <p className="font-medium">${connectedSafe.balance} USDC</p>
+                    <p className="font-medium">
+                      {connectedSafe.balance} USDC
+                    </p>
                     <p className="text-slate-500">
                       {connectedSafe.address.slice(0, 6)}...{connectedSafe.address.slice(-4)}
                     </p>
@@ -464,7 +466,9 @@ export default function ShotgunBlastApp() {
                 </div>
                 <div>
                   <span className="text-sm text-gray-600">Total Amount:</span>
-                  <p className="font-semibold text-lg">${totalAmount.toLocaleString()}</p>
+                  <p className="font-semibold text-lg">
+                    {totalAmount.toLocaleString()}
+                  </p>
                 </div>
                 <div>
                   <span className="text-sm text-gray-600">Token:</span>
@@ -472,7 +476,9 @@ export default function ShotgunBlastApp() {
                 </div>
                 <div>
                   <span className="text-sm text-gray-600">Safe Balance:</span>
-                  <p className="font-semibold text-lg">${connectedSafe?.balance}</p>
+                  <p className="font-semibold text-lg">
+                    {connectedSafe?.balance}
+                  </p>
                 </div>
               </div>
 
@@ -687,7 +693,9 @@ export default function ShotgunBlastApp() {
                   </div>
                   <div>
                     <span className="text-sm text-gray-600">Total Amount:</span>
-                    <p className="font-semibold text-lg">${totalAmount.toLocaleString()}</p>
+                    <p className="font-semibold text-lg">
+                      {totalAmount.toLocaleString()}
+                    </p>
                   </div>
                   <div>
                     <span className="text-sm text-gray-600">Privacy Level:</span>

--- a/proposal-dashboard.tsx
+++ b/proposal-dashboard.tsx
@@ -299,7 +299,7 @@ export default function RailgunProposal() {
                   <div className="grid grid-cols-2 gap-4 text-sm">
                     <div>
                       <span className="text-slate-600">Total Amount:</span>
-                      <p className="font-semibold">${totalAmount.toLocaleString()} USDC</p>
+                      <p className="font-semibold">{totalAmount.toLocaleString()} USDC</p>
                     </div>
                     <div>
                       <span className="text-slate-600">Estimated Gas:</span>


### PR DESCRIPTION
## Summary
- fix string interpolation when showing Safe balances and totals

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c62a8c008327885a4ce8a429773a